### PR TITLE
[ROS Lunar] Use mockups pkg as a smoke test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
     - ROS_DISTRO=kinetic AFTER_SCRIPT='catkin --version'
     - ROS_DISTRO=kinetic NOT_TEST_BUILD='true' DEBUG_BASH='true' VERBOSE_OUTPUT='false'
     - ROS_DISTRO=lunar ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO=lunar USE_MOCKUP='industrial_ci/mockups/industrial_ci_testpkg'
 matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo NOT_TEST_BUILD='true' NOT_TEST_INSTALL='true' POST_PROCESS='I_am_supposed_to_fail'


### PR DESCRIPTION
This addresses the concern raised at https://github.com/ros-industrial/industrial_ci/pull/131#issuecomment-281162743

> The [`lunar` job](https://travis-ci.org/ros-industrial/industrial_ci/jobs/203429152) passing already doesn't make sense to me, when there are only a couple of packages (I forgot what they were back then. Today more core packages have been already [released](http://repositories.ros.org/status_page/ros_lunar_default.html))?

Looking at the commit history at [rosdistro/lunar/distribution.yaml](https://github.com/ros/rosdistro/commits/master/lunar/distribution.yaml), the two package that became available for Lunar first were `catkin` and `gencpp`, which are not sufficient for any catkin package to pass the test IMO.

I noticed that for Lunar job the tests in `industrial_ci_testpkg`, which should fail with only the aforementioned two packages available, are not used. So are they added here.